### PR TITLE
update: deploy factory in constant mnemonic

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,14 +3,10 @@ import '@typechain/hardhat'
 import { HardhatUserConfig } from 'hardhat/config'
 import 'hardhat-deploy'
 import '@nomiclabs/hardhat-etherscan'
-
 import 'solidity-coverage'
 
-import * as fs from 'fs'
-
-const mnemonicFileName = process.env.MNEMONIC_FILE ?? `${process.env.HOME}/.secret/testnet-mnemonic.txt`
-let mnemonic = 'test '.repeat(11) + 'junk'
-if (fs.existsSync(mnemonicFileName)) { mnemonic = fs.readFileSync(mnemonicFileName, 'ascii') }
+// test mnemonic
+let mnemonic = 'amateur flash tilt happy list lunar around funny apart flame fabric fashion';
 
 function getNetwork1 (url: string): { url: string, accounts: { mnemonic: string } } {
   return {

--- a/src/Create2Factory.ts
+++ b/src/Create2Factory.ts
@@ -100,7 +100,7 @@ export class Create2Factory {
     }
 
     let userAddr = await this.signer.getAddress();
-
+    
     // build the transaction
     const unsignedTx = {
       from: userAddr,
@@ -113,6 +113,7 @@ export class Create2Factory {
     let receipt = await tx.wait();
 
     Create2Factory.contractAddress = receipt.contractAddress;
+    console.log("Create2Factory Address: ", Create2Factory.contractAddress);
 
     if (!await this._isFactoryDeployed()) {
       throw new Error('fatal: failed to deploy deterministic deployer')


### PR DESCRIPTION
To prevent confusion of mnemonic, we assigned mnemonic for testing to the constant variable and confirmed that it works properly.

Please check if you deployed it exactly with the execution command below, and if you execute the command after you pull the merged code, you can confirm that it works normally

If it is a problem caused by a different execution environment, it is expected that it will be difficult to identify, so I'm also sharing the deployed factory address.

deploy address of factory : https://explorer.testnet.thebifrost.io/address/0x20F697b303481445Cb84ad836c8336634E7b53ad

[Execution Command]
`npx hardhat test test/create2factory.test.ts --network bifrostt`